### PR TITLE
Keep at least one word in a string when `words` is set to `true` even if it's longer than a target length

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ If `words` is truthy the input will only be truncated at word boundaries.
 '<p>Stuff and…</p>'
 ```
 
+### keepFirstWord
+
+*Default: false*
+
+When `words` and `keepFirstWord` are both truthy the input will contain
+at least one word beside the ellipsis even if it's longer than
+a target length.
+
+```javascript
+> jQuery.truncate('<p>Stuff and <i>Nonsense</i></p>', {
+  length: 4,
+  words: true,
+  keepFirstWord: true
+});
+'<p>Stuff…</p>'
+```
+
 ### noBreaks
 
 *Default: false*

--- a/jquery.truncate.js
+++ b/jquery.truncate.js
@@ -3,6 +3,9 @@
   // Matches trailing non-space characters.
   var chop = /(\s*\S+|\s)$/;
 
+  // Matches the first word in the string.
+  var start = /^(\S*)/;
+
   // Return a truncated html string.  Delegates to $.fn.truncate.
   $.truncate = function(html, options) {
     return $('<div></div>').append(html).truncate(options).html();
@@ -25,7 +28,13 @@
 
       // Chop off any partial words if appropriate.
       if (o.words && excess > 0) {
-        excess = text.length - text.slice(0, o.length).replace(chop, '').length - 1;
+        var truncated = text.slice(0, o.length).replace(chop, '').length;
+
+        if (o.keepFirstWord && truncated === 0) {
+          excess = text.length - start.exec(text)[0].length - 1;
+        } else {
+          excess = text.length - truncated - 1;
+        }
       }
 
       if (excess < 0 || !excess && !o.truncated) return;
@@ -64,6 +73,10 @@
 
     // Only truncate at word boundaries.
     words: false,
+
+    // When 'words' is active, keeps the first word in the string
+    // even if it's longer than a target length.
+    keepFirstWord: false,
 
     // Replace instances of <br> with a single space.
     noBreaks: false,

--- a/test/index.js
+++ b/test/index.js
@@ -33,6 +33,11 @@
     strictEqual($.truncate(txt, {length: 14, words: true}), 'stuff and…');
     strictEqual($.truncate(txt, {length: 10, words: true}), 'stuff and…');
     strictEqual($.truncate(txt, {length: 9, words: true}), 'stuff…');
+    strictEqual($.truncate(txt, {length: 4, words: true}), '…');
+  });
+
+  test('keepLastWord', function () {
+    strictEqual($.truncate(txt, {length: 4, words: true, keepFirstWord: true}), 'stuff…');
   });
 
   test('noBreaks', function() {


### PR DESCRIPTION
Adding `keepFirstWord` option to support use cases when truncation is supposed to happen at word boundaries, but at least one word should be left intact in the string even if it's longer than a target length.

Particularly makes sense if the word is in fact a URL or a hash that has no spaces, but `length` is set to a value that is less than that "word's" length and it's not 100% critical to fit everything into that exact given `length`.

Please let me know if you have any questions or concerns about the changes I'm making.